### PR TITLE
Fix clang build warnings

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,6 +1,9 @@
 COMPONENT_SRCDIRS := $(call ListAllSubDirs,$(COMPONENT_PATH)/src)
 COMPONENT_INCDIRS := src
-COMMON_FLAGS := -Wno-sign-compare -Wno-strict-aliasing -Wno-deprecated-declarations -Wno-nonnull -lm
+COMMON_FLAGS := -Wno-sign-compare -Wno-strict-aliasing -Wno-deprecated-declarations -Wno-nonnull
+ifeq ($(GCC_NAME),gcc)
+	COMMON_FLAGS += -lm
+endif
 ifneq ($(SMING_ARCH),Host)
 	COMMON_FLAGS += -D__ANDROID__=0 
 endif

--- a/samples/TensorFlow_HelloWorld/app/application.cpp
+++ b/samples/TensorFlow_HelloWorld/app/application.cpp
@@ -43,7 +43,7 @@ uint8_t tensor_arena[kTensorArenaSize];
 
 Timer procTimer;
 
-const int ledPin = 2; // GPIO2
+// const int ledPin = 2; // GPIO2
 
 // Track whether the function has run at least once
 bool initialized = false;

--- a/src/tensorflow/lite/micro/micro_utils.cpp
+++ b/src/tensorflow/lite/micro/micro_utils.cpp
@@ -104,7 +104,7 @@ int8_t FloatToSymmetricQuantizedInt8(const float value, const float scale) {
 }
 
 int32_t FloatToSymmetricQuantizedInt32(const float value, const float scale) {
-  float quantized = round(value / scale);
+  int64_t quantized = round(value / scale);
   if (quantized > INT_MAX) {
     quantized = INT_MAX;
   } else if (quantized < INT_MIN) {
@@ -249,13 +249,13 @@ void SignedSymmetricQuantize(const float* values, TfLiteIntArray* dims,
     max = fmaxf(max, values[i]);
   }
 
-  *scaling_factor = fmaxf(fabs(min), fabs(max)) / kSymmetricInt32Scale;
+  *scaling_factor = fmaxf(fabs(min), fabs(max)) / float(kSymmetricInt32Scale);
   for (int i = 0; i < input_size; i++) {
     const int32_t quantized_value =
         static_cast<int32_t>(roundf(values[i] / *scaling_factor));
     // Clamp: just in case some odd numeric offset.
-    quantized_values[i] = fminf(kSymmetricInt32Scale,
-                                fmaxf(-kSymmetricInt32Scale, quantized_value));
+    quantized_values[i] = fminf(float(kSymmetricInt32Scale),
+                                fmaxf(float(-kSymmetricInt32Scale), quantized_value));
   }
 }
 


### PR DESCRIPTION
Specifically:

```
clang++: warning: -lm: 'linker' input unused [-Wunused-command-line-argument]

Sming/Libraries/Arduino_TensorFlowLite/src/tensorflow/lite/micro/micro_utils.cpp:252:51:
warning: implicit conversion from 'const int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
252 |   *scaling_factor = fmaxf(fabs(min), fabs(max)) / kSymmetricInt32Scale;
```

Not tested!