### PR TITLE
Disable platform optimisations

### DIFF
--- a/src/tensorflow/lite/kernels/internal/optimized/neon_check.h
+++ b/src/tensorflow/lite/kernels/internal/optimized/neon_check.h
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_OPTIMIZED_NEON_CHECK_H_
+#if 0 // no optimisations
 #define TENSORFLOW_LITE_KERNELS_INTERNAL_OPTIMIZED_NEON_CHECK_H_
 
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)

--- a/src/third_party/gemmlowp/internal/detect_platform.h
+++ b/src/third_party/gemmlowp/internal/detect_platform.h
@@ -15,7 +15,7 @@
 // detect_platform.h: Sets up macros that control architecture-specific
 // features of gemmlowp's implementation.
 
-#ifndef GEMMLOWP_INTERNAL_DETECT_PLATFORM_H_
+#if 0 // no optimisations
 #define GEMMLOWP_INTERNAL_DETECT_PLATFORM_H_
 
 // Our inline assembly path assume GCC/Clang syntax.


### PR DESCRIPTION
Build breaks for Host builds in MacOS.
Host builds should use same code as for devices.